### PR TITLE
fix Rectifier model parsing, closes lp-research/lpslam_node#18

### DIFF
--- a/src/openvslam/system.cc
+++ b/src/openvslam/system.cc
@@ -115,9 +115,14 @@ system::system(const std::shared_ptr<config>& cfg, const std::string& vocab_file
     global_optimizer_ = new global_optimization_module(map_db_, bow_db_, bow_vocab_, cfg_->yaml_node_, camera_->setup_type_ != camera::setup_type_t::Monocular);
 
 
-    // create retifier, make optional
-    if (cfg_->yaml_node_["StereoRectifier.model"]) {
-        rectifier_ = std::make_unique<util::stereo_rectifier>(cfg_);
+    // create rectifier, make optional
+    if (cfg_->yaml_node_["StereoRectifier"]) {
+        if (cfg_->yaml_node_["StereoRectifier"]["model"]) {
+            spdlog::info("rectifier model found, going to rectify");
+            rectifier_ = std::make_unique<util::stereo_rectifier>(cfg_);
+        }
+    } else {
+        spdlog::warn("rectifier model not found in the config, skipping this step");
     }
 
     // connect modules each other

--- a/src/openvslam/util/stereo_rectifier.cc
+++ b/src/openvslam/util/stereo_rectifier.cc
@@ -1,6 +1,7 @@
 #include "openvslam/camera/perspective.h"
 #include "openvslam/camera/fisheye.h"
 #include "openvslam/util/stereo_rectifier.h"
+#include "openvslam/util/yaml.h"
 
 #include <spdlog/spdlog.h>
 #include <opencv2/imgproc.hpp>
@@ -9,7 +10,8 @@ namespace openvslam {
 namespace util {
 
 stereo_rectifier::stereo_rectifier(const std::shared_ptr<openvslam::config>& cfg)
-    : stereo_rectifier(cfg->camera_, cfg->yaml_node_) {}
+    : stereo_rectifier(cfg->camera_,
+                        openvslam::util::yaml_optional_ref(cfg->yaml_node_, "StereoRectifier")){}
 
 stereo_rectifier::stereo_rectifier(camera::base* camera, const YAML::Node& yaml_node)
     : model_type_(load_model_type(yaml_node)) {


### PR DESCRIPTION
This will enable stereo rectification OpenVSLAM side and fix [this issue](https://github.com/lp-research/lpslam_node/issues/18). 
